### PR TITLE
Add support for BitBucket VCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ These metrics have "job", "workflow", "repo" and "branch" tags.
 |CIRCLECI_API_INTERVAL|no      |300(sec)|Interval second for calling the API|
 |GITHUB_REPOSITORY    |yes     |-       |Comma-separated repository names. i.e. "chaspy/chaspy.me,chaspy/dotfiles"|
 |GITHUB_BRANCH        |yes     |-       |Comma-separated branch names. i.e. "master,develop"|
+|BITBUCKET_REPOSITORY |no      |-       |Comma-separated repository names. i.e. "chaspy/chaspy.me,chaspy/dotfiles"|
+|BITBUCKET_BRANCH     |no      |-       |Comma-separated branch names. i.e. "master,develop"|
+
+Use either BITBUCKET_* or GITHUB_* pair of environment variables, exclusively. Setting the pair will define which repository provider should be used.
+
 
 ## Datadog Autodiscovery
 

--- a/pkg/api/v2/insights/summary/jobs/jobs.go
+++ b/pkg/api/v2/insights/summary/jobs/jobs.go
@@ -147,20 +147,20 @@ func getV2WorkflowJobsInsights(workflowWithRepos []workflows.WorkflowWithRepo) (
 
 	reportingWindow := config.GetReportingWindow()
 
-	branches, err := config.GetGitHubBranches()
+	_, branches, git_provider, err := config.GetRepositoryConfig()
 	if err != nil {
-		return []WorkflowJobsInsightWithRepo{}, fmt.Errorf("failed to read GitHub branch: %w", err)
+		return []WorkflowJobsInsightWithRepo{}, fmt.Errorf("failed to read configuration: %w", err)
 	}
 
 	getCircleCIToken, err := config.GetCircleCIToken()
 	if err != nil {
-		log.Fatal("failed to read Datadog Config: %w", err)
+		log.Fatal("failed to read CircleCI token: %w", err)
 	}
 
 	for _, workflowWithRepo := range workflowWithRepos {
 		for _, branch := range branches {
 			for {
-				url := "https://circleci.com/api/v2/insights/gh/" + workflowWithRepo.Repo + "/workflows/" + workflowWithRepo.Workflow + "/jobs" + "?branch=" + branch + "&reporting-window=" + reportingWindow + "&page-token" + pageToken
+				url := "https://circleci.com/api/v2/insights/" + git_provider + "/" + workflowWithRepo.Repo + "/workflows/" + workflowWithRepo.Workflow + "/jobs" + "?branch=" + branch + "&reporting-window=" + reportingWindow + "&page-token" + pageToken
 
 				ctx := context.Background()
 				req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,22 +15,27 @@ func GetCircleCIToken() (string, error) {
 	return circleciToken, nil
 }
 
-func GetGitHubRepos() ([]string, error) {
-	githubRepos := os.Getenv("GITHUB_REPOSITORY")
-	if len(githubRepos) == 0 {
-		return []string{}, fmt.Errorf("missing environment variable GITHUB_REPOSITORY")
+func GetConfigForName(config_name string) ([]string, []string) {
+	if len(os.Getenv(config_name+"_REPOSITORY")) > 0 && len(os.Getenv(config_name+"_BRANCH")) > 0 {
+		return strings.Split(os.Getenv(config_name+"_REPOSITORY"), ","), strings.Split(os.Getenv(config_name+"_BRANCH"), ",")
 	}
-	ret := strings.Split(githubRepos, ",")
-	return ret, nil
+	return []string{}, []string{}
 }
 
-func GetGitHubBranches() ([]string, error) {
-	githubBranches := os.Getenv("GITHUB_BRANCH")
-	if len(githubBranches) == 0 {
-		return []string{}, fmt.Errorf("missing environment variable GITHUB_BRANCH")
+func GetRepositoryConfig() ([]string, []string, string, error) {
+
+	repos, branches := GetConfigForName("GITHUB")
+	if len(repos) > 0 && len(branches) > 0 {
+		return repos, branches, "gh", nil
 	}
-	ret := strings.Split(githubBranches, ",")
-	return ret, nil
+
+	repos, branches = GetConfigForName("BITBUCKET")
+	if len(repos) > 0 && len(branches) > 0 {
+		return repos, branches, "bb", nil
+	}
+
+	return []string{}, []string{}, "", fmt.Errorf("Missing environment variables. " +
+		"Define either GITHUB_REPOSITORY and GITHUB_BRANCH, or BITBUCKET_REPOSITORY and BITBUCKET_BRANCH")
 }
 
 // reporting window expect the followings:


### PR DESCRIPTION
Second attempt for this PR, first one got botched somehow with conflicts.

Basically, this adds an option to start the exporter in a mode that uses BitBucket VCS instead of GitHub. As not everybody is using GH, i figure this would be useful for other people.

Tested locally, works fine.